### PR TITLE
Problem: recent version of jira package caused the exception to move to a different module

### DIFF
--- a/jiracli/bridge/rest.py
+++ b/jiracli/bridge/rest.py
@@ -2,7 +2,7 @@
 
 """
 from jira.client import JIRA
-from jira.exceptions import JIRAError
+from jira.utils import JIRAError
 from jira.resources import Resource
 from requests import RequestException
 from jiracli.bridge import JiraBridge

--- a/jiracli/errors.py
+++ b/jiracli/errors.py
@@ -1,4 +1,4 @@
-from jira.exceptions import JIRAError
+from jira.utils import JIRAError
 from suds import WebFault
 
 

--- a/jiracli/interface.py
+++ b/jiracli/interface.py
@@ -2,7 +2,7 @@
 
 """
 import argparse
-from jira.exceptions import JIRAError
+from jira.utils import JIRAError
 
 from suds import WebFault
 import sys


### PR DESCRIPTION
I fixed the import and nothing else seems to have broken. However on my box I still got 3 tests that were failing.