### PR TITLE
Use the keyring module to store password credentials securely.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ jira
 requests
 argparse
 suds-jurko
+keyring


### PR DESCRIPTION
This is a tiny change which pulls in a dependency on the keyring module, which provides cross-platform support for various keyring backing platforms. This thus securely stores and retrieves the JIRA password.