### PR TITLE
Added support for json in the extra field

### DIFF
--- a/jiracli/processor.py
+++ b/jiracli/processor.py
@@ -30,6 +30,10 @@ class Command(object):
             extras = {}
             for item in self.args.extra_fields:
                 key, value = item.split("=")
+                try:
+                    value = json.loads(value)
+                except ValueError:
+                    pass
                 if key in extras:
                     if not isinstance(extras[key], list):
                         v = [extras[key]]


### PR DESCRIPTION
This makes it possible to create something like this:
jira-cli new --extra customfield_10001='{"name": "username"}' ...
This is intended for customfields with more than only freetext.