### PR TITLE
Set labels only if there are labels to be set

### DIFF
--- a/jiracli/bridge/rest.py
+++ b/jiracli/bridge/rest.py
@@ -86,9 +86,10 @@ class JiraRestBridge(JiraBridge):
             "summary": summary,
             "description": description,
             "priority": {'id':self.get_priorities()[priority.lower()]["id"]},
-            "labels": labels,
             "components": [{"name": k} for k in components.keys()]
         }
+        if labels:
+            issue['labels'] = labels
         if not issue["components"]:
             issue.pop("components")
         if type.lower() == 'epic':


### PR DESCRIPTION
Issues can be configured to not have labels. When that's the case,
attempting to create a ticket would result in the error:

    Field 'labels' cannot be set. It is not on the appropriate screen,
    or unknown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alisaifee/jira-cli/45)
<!-- Reviewable:end -->
