### PR TITLE
Make it possible to set the issue description to a blank string through command line

### DIFF
--- a/jiracli/interface.py
+++ b/jiracli/interface.py
@@ -150,7 +150,7 @@ def build_parser():
     add.add_argument('--project', dest='issue_project',
                      help='project to create new issue in')
     add.add_argument('--description', dest='issue_description',
-                     help='description of new issue')
+                     help='description of new issue', default=None)
     add.add_argument('--type', dest='issue_type', help='new issue priority')
     add.add_argument('--parent', dest='issue_parent',
                      help='parent of new issue')

--- a/jiracli/interface.py
+++ b/jiracli/interface.py
@@ -11,12 +11,13 @@ from jiracli.bridge import get_bridge
 from jiracli.cache import clear_cache
 from jiracli.errors import JIRAError
 from jiracli.errors import JiraAuthenticationError, JiraInitializationError
-from jiracli.errors import  UsageWarning, JiraCliError, UsageError
+from jiracli.errors import UsageWarning, JiraCliError, UsageError
 from jiracli.processor import ViewCommand, AddCommand, UpdateCommand
 from jiracli.processor import ListCommand
 from jiracli.utils import print_error, WARNING, Config, colorfunc, prompt, \
     print_output
 from jiracli.cli import main as old_main
+
 
 def initialize(config, base_url=None, username=None, password=None,
                persist=True, error=False, protocol='soap'):
@@ -25,43 +26,38 @@ def initialize(config, base_url=None, username=None, password=None,
     if error or not (url and bridge and bridge.ping()):
         url = url or prompt("Base url for the jira instance: ")
         username = (
-            username
-            or (not error and config.username)
-            or prompt("username: ")
+            username or
+            (not error and config.username) or
+            prompt("username: ")
         )
         password = (
-            password
-            or (not error and keyring.get_password('jira-cli',username))
-            or prompt("password: ", True)
+            password or
+            (not error and keyring.get_password('jira-cli', username)) or
+            prompt("password: ", True)
         )
         jira = not error and bridge or get_bridge(protocol)(url, config, persist)
         persist_warning = "would you like to persist the credentials to the local keyring? [y/n]:"
 
         first_run = (
             not(
-                config.base_url
-                or config.username
-                or keyring.get_password('jira-cli',username)
+                config.base_url or
+                config.username or
+                keyring.get_password('jira-cli', username)
             )
         )
         if persist or first_run:
             config.base_url = url
             config.save()
-            keyring.set_password('jira-cli',username,password)
+            keyring.set_password('jira-cli', username, password)
         try:
             jira.login(username, password)
             if (
-                (persist or first_run)
-                 and (
-                    not (
-                        config.username == username
-                        or config.password == password
-                    )
-                )
-                and "y" == prompt(persist_warning)
+                (persist or first_run) and
+                (not (config.username == username or config.password == password)) and
+                "y" == prompt(persist_warning)
             ):
                 config.username = username
-                keyring.set_password('jira-cli',username,password)
+                keyring.set_password('jira-cli', username, password)
                 config.save()
             config.save()
             return jira
@@ -88,37 +84,35 @@ def build_parser():
     parser.add_argument('--v2', dest='v2', action='store_true',
                         help='use jira-cli v2', default=True)
 
-
     base = argparse.ArgumentParser(description='jira-cli-base', add_help=False)
     base.add_argument('--jira-url', dest='jira_url',
-                        help='the base url for the jira instance', default=None)
+                      help='the base url for the jira instance', default=None)
     base.add_argument("--format", dest="format", default=None,
-                        help=r'format for displaying ticket information. '
-                             r'allowed tokens: status,priority,updated,votes,'
-                             r'components,project,reporter,created,fixVersions,'
-                             r'summary,environment,assignee,key,'
-                             r'affectsVersions,type.'
-                             r'Use the %% character before each token '
-                             r'(example: issue id: %%key [%%priority])')
+                      help=r'format for displaying ticket information. '
+                           r'allowed tokens: status,priority,updated,votes,'
+                           r'components,project,reporter,created,fixVersions,'
+                           r'summary,environment,assignee,key,'
+                           r'affectsVersions,type.'
+                           r'Use the %% character before each token '
+                           r'(example: issue id: %%key [%%priority])')
     base.add_argument('--oneline', dest='oneline',
-                        help='built in format to display each ticket on one line',
-                        action='store_true')
+                      help='built in format to display each ticket on one line',
+                      action='store_true')
     base.add_argument('-v', dest='verbosity', help='amount of detail to show for issues',
-                        action='count')
+                      action='count')
     base.add_argument('-u', '--username', dest='username',
-                        help='username to login as', default=None)
+                      help='username to login as', default=None)
     base.add_argument('-p', '--password', dest='password',
-                        help='password for jira instance', default=None)
+                      help='password for jira instance', default=None)
     base.add_argument('--protocol', dest='protocol',
-                        choices = ['soap','rest'], help='the protocol to use to communicate with jira',
-                        )
+                      choices=['soap', 'rest'], help='the protocol to use to communicate with jira')
 
     view = subparsers.add_parser('view', parents=[base], help='view/list/search for issues')
     view.set_defaults(cmd=ViewCommand)
     add = subparsers.add_parser('new', parents=[base], help='create a new issue')
     add.add_argument('--extra', dest='extra_fields',
-                        nargs='?', action='append',
-                        help='extra fields for the new ticket')
+                     nargs='?', action='append',
+                     help='extra fields for the new ticket')
     add.set_defaults(cmd=AddCommand)
     update = subparsers.add_parser('update', parents=[base], help='update existing issues')
     update.set_defaults(cmd=UpdateCommand)
@@ -138,7 +132,6 @@ def build_parser():
                       help='displays only the comments assosciated with each issue',
                       action='store_true')
     view.add_argument('jira_ids', nargs='*', help='jira issue ids')
-
 
     list.add_argument('type', choices=['filters', 'projects', 'issue_types',
                                        'subtask_types', 'priorities',
@@ -162,13 +155,13 @@ def build_parser():
     add.add_argument('--parent', dest='issue_parent',
                      help='parent of new issue')
     add.add_argument('--label', dest='labels',
-                        nargs='?', action='append',
-                        help='label to add to the ticket')
+                     nargs='?', action='append',
+                     help='label to add to the ticket')
     add.add_argument('--assignee', dest='issue_assignee', help='new issue assignee')
     add.add_argument('--reporter', dest='issue_reporter', help='new issue reporter')
     add.add_argument('--component', dest='issue_components',
-                        action='append', help='components(s) for the new issue'
-                                              ' (use list components to view available components)')
+                     action='append', help='components(s) for the new issue'
+                                           ' (use list components to view available components)')
 
     update.add_argument('issue', help='the jira issue to act on')
 
@@ -218,19 +211,24 @@ def build_parser():
 
     return parser
 
+
 def fake_parse(args):
     import optparse
+
     class FakeParser(optparse.OptionParser):
         def print_usage(self, file=None):
             raise SystemExit()
+
         def print_help(self, file=None):
             raise StopIteration()
+
     optparser = FakeParser()
     optparser.add_option("", "--v1", action='store_true', default=False)
     optparser.add_option("", "--protocol", dest='protocol', default='rest')
     optparser.add_option("", "--version", action='store_true', default=False)
     opts, args = optparser.parse_args(args)
     return opts, args
+
 
 def cli(args=sys.argv[1:]):
     parser = build_parser()
@@ -255,8 +253,8 @@ def cli(args=sys.argv[1:]):
             print(__version__)
             return
         if (
-            not (pre_opts or pre_args) or (pre_opts and not (pre_opts.v1 or config.v1))
-            and not (pre_opts and ("configure" in pre_args or "clear_cache" in pre_args))
+            not (pre_opts or pre_args) or (pre_opts and not (pre_opts.v1 or config.v1)) and
+            not (pre_opts and ("configure" in pre_args or "clear_cache" in pre_args))
         ):
             post_args = parser.parse_args(args)
             jira = initialize(
@@ -289,6 +287,7 @@ def cli(args=sys.argv[1:]):
         print_error(JiraCliError(e))
     except NotImplementedError as e:
         print_error(e)
+
 
 if __name__ == "__main__":
     cli()

--- a/jiracli/processor.py
+++ b/jiracli/processor.py
@@ -14,11 +14,13 @@ try:
 except ImportError:
     from ordereddict import OrderedDict
 
+
 @six.add_metaclass(ABCMeta)
 class Command(object):
     def __init__(self, jira, args):
         self.args = args
         self.jira = jira
+
     @abstractmethod
     def eval(self):
         raise NotImplementedError
@@ -56,13 +58,13 @@ class ViewCommand(Command):
         else:
             mode = 0
         if self.args.search_freetext:
-            issues = self.jira.search_issues(self.args.search_freetext, project = self.args.project)
+            issues = self.jira.search_issues(self.args.search_freetext, project=self.args.project)
         elif self.args.search_jql:
             issues = self.jira.search_issues_jql(self.args.search_jql)
         elif self.args.filter:
             issues = self.jira.get_issues_by_filter(*self.args.filter)
         else:
-            issues = filter(lambda issue:issue is not None, [self.jira.get_issue(jira) for jira in self.args.jira_ids])
+            issues = filter(lambda issue: issue is not None, [self.jira.get_issue(jira) for jira in self.args.jira_ids])
 
         for issue in issues:
             print_output(self.jira.format_issue(
@@ -71,6 +73,7 @@ class ViewCommand(Command):
                 formatter=self.args.format,
                 comments_only=self.args.comments_only
             ))
+
 
 class ListCommand(Command):
     def eval(self):
@@ -177,22 +180,22 @@ class UpdateCommand(Command):
                 '%s labelled with %s' % (self.args.issue, ",".join(self.args.labels)), 'green'
             ))
         if self.args.affects_version:
-            self.jira.add_versions(self.args.issue, self.args.affects_version,'affects')
+            self.jira.add_versions(self.args.issue, self.args.affects_version, 'affects')
             print_output(colorfunc(
                 'Added affected version(s) %s to %s' % (",".join(self.args.affects_version), self.args.issue), 'green'
             ))
         if self.args.remove_affects_version:
-            self.jira.remove_versions(self.args.issue, self.args.remove_affects_version,'affects')
+            self.jira.remove_versions(self.args.issue, self.args.remove_affects_version, 'affects')
             print_output(colorfunc(
                 'Removed affected version(s) %s from %s' % (",".join(self.args.remove_affects_version), self.args.issue), 'blue'
             ))
         if self.args.fix_version:
-            self.jira.add_versions(self.args.issue, self.args.fix_version,'fix')
+            self.jira.add_versions(self.args.issue, self.args.fix_version, 'fix')
             print_output(colorfunc(
                 'Added fixed version(s) %s to %s' % (",".join(self.args.fix_version), self.args.issue), 'green'
             ))
         if self.args.remove_fix_version:
-            self.jira.remove_versions(self.args.issue, self.args.remove_fix_version,'fix')
+            self.jira.remove_versions(self.args.issue, self.args.remove_fix_version, 'fix')
             print_output(colorfunc(
                 'Removed fixed version(s) %s from %s' % (",".join(self.args.remove_fix_version), self.args.issue), 'blue'
             ))
@@ -215,7 +218,7 @@ class AddCommand(Command):
         if self.args.issue_parent:
             if not self.args.issue_type:
                 self.args.issue_type = 'sub-task'
-            if not self.args.issue_type in self.jira.get_subtask_issue_types():
+            if self.args.issue_type not in self.jira.get_subtask_issue_types():
                 raise UsageError(
                     "issues created with parents must be one of {%s}" % ",".join(self.jira.get_subtask_issue_types())
                 )
@@ -236,14 +239,9 @@ class AddCommand(Command):
                 components = {k: valid_components[k] for k in self.args.issue_components}
         description = self.args.issue_description or get_text_from_editor()
         print_output(self.jira.format_issue(
-            self.jira.create_issue(self.args.issue_project, self.args.issue_type, self.args.title, description,
-                               self.args.issue_priority, self.args.issue_parent, self.args.issue_assignee,
-                               self.args.issue_reporter, self.args.labels, components, **extras)
+            self.jira.create_issue(
+                self.args.issue_project, self.args.issue_type, self.args.title, description,
+                self.args.issue_priority, self.args.issue_parent, self.args.issue_assignee,
+                self.args.issue_reporter, self.args.labels, components, **extras
+            )
         ))
-
-
-
-
-
-
-

--- a/jiracli/processor.py
+++ b/jiracli/processor.py
@@ -237,7 +237,10 @@ class AddCommand(Command):
                 )
             else:
                 components = {k: valid_components[k] for k in self.args.issue_components}
-        description = self.args.issue_description or get_text_from_editor()
+        if self.args.issue_description is not None:
+            description = self.args.issue_description
+        else:
+            description = get_text_from_editor()
         print_output(self.jira.format_issue(
             self.jira.create_issue(
                 self.args.issue_project, self.args.issue_type, self.args.title, description,

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -72,6 +72,25 @@ class CliParsingTests(unittest.TestCase):
                 allowed
             )
 
+    def test_new_subcommand(self):
+        parser = build_parser()
+        args = parser.parse_args(['new', '--project=TP', '--type=Story',  'Issue title'])
+        self.assertEqual(args.title, 'Issue title')
+        self.assertEqual(args.issue_project, 'TP')
+        self.assertEqual(args.issue_type, 'Story')
+
+    def test_new_subcommand_description_is_none_by_default(self):
+        """ Test that the description is None if missing, when adding new issue. """
+        parser = build_parser()
+        args = parser.parse_args(['new', '--project=TP', '--type=Story',  'Issue title'])
+        self.assertEqual(args.issue_description, None)
+
+    def test_new_subcommand_description_can_be_a_blank_string(self):
+        """ Test that the description can be set to a blank string explicitly, when adding new issue. """
+        parser = build_parser()
+        args = parser.parse_args(['new', '--project=TP', '--type=Story', '--description=', 'Issue title'])
+        self.assertEqual(args.issue_description, '')
+
 
 class CliInitParsing(unittest.TestCase):
 


### PR DESCRIPTION
Now, it is possible to set the issue description to a blank string without the need to open the editor, making it possible to run the cli command in a shell loop, for instance.

Fixes #47

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alisaifee/jira-cli/51)
<!-- Reviewable:end -->
