### PR TITLE
Fix url_str construction when --oneline is passed.

### DIFF
--- a/jiracli/bridge/__init__.py
+++ b/jiracli/bridge/__init__.py
@@ -110,7 +110,7 @@ class JiraBridge(object):
         if comments_only:
             return fields["comments"].strip()
         elif mode < 0:
-            url_str = colorfunc(parse.urljoin(self.base_url, "/browse/%s" % (issue["key"])), "white", attrs=["underline"])
+            url_str = colorfunc("%s/browse/%s" % (self.base_url, issue["key"]), "white", attrs=["underline"])
             ret_str = colorfunc(issue["key"], status_color) + " " + issue.setdefault("summary", "") + " " + url_str
             if not COLOR:
                 ret_str += " [%s] " % status_string


### PR DESCRIPTION
e.g. If self.base_url was 'https://a.b.c/jira',
Before: 'https://a.b.c/browse/PROJECT-123', After: 'https://a.b.c/jira/browse/PROJECT-123'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alisaifee/jira-cli/61)
<!-- Reviewable:end -->
