### PR TITLE
Dict_keys types can not be concatenated, leading to error:

### DIFF
--- a/jiracli/processor.py
+++ b/jiracli/processor.py
@@ -219,7 +219,7 @@ class AddCommand(Command):
             issue_types = list(self.jira.get_issue_types().keys()) + list(self.jira.get_subtask_issue_types().keys())
         else:
             issue_types = self.jira.get_issue_types().keys() + self.jira.get_subtask_issue_types().keys()
-        if self.args.issue_type and not self.args.issue_type.lower() in issue_types):
+        if self.args.issue_type and not self.args.issue_type.lower() in issue_types:
             raise UsageError(
                 "invalid issue type: %s (try using jira-cli "
                 "list issue_types or jira-cli list subtask_types)" % self.args.issue_type

--- a/jiracli/processor.py
+++ b/jiracli/processor.py
@@ -212,7 +212,7 @@ class AddCommand(Command):
             raise UsageError('project must be specified when creating an issue')
         if not (self.args.issue_parent or self.args.issue_type):
             self.args.issue_type = 'bug'
-        if self.args.issue_type and not self.args.issue_type.lower() in self.jira.get_issue_types().keys() + self.jira.get_subtask_issue_types().keys():
+        if self.args.issue_type and not self.args.issue_type.lower() in list(self.jira.get_issue_types().keys()) + list(self.jira.get_subtask_issue_types().keys()):
             raise UsageError(
                 "invalid issue type: %s (try using jira-cli "
                 "list issue_types or jira-cli list subtask_types)" % self.args.issue_type

--- a/jiracli/processor.py
+++ b/jiracli/processor.py
@@ -3,6 +3,8 @@
 """
 from abc import ABCMeta, abstractmethod
 
+import sys
+
 import json
 import six
 
@@ -212,7 +214,12 @@ class AddCommand(Command):
             raise UsageError('project must be specified when creating an issue')
         if not (self.args.issue_parent or self.args.issue_type):
             self.args.issue_type = 'bug'
-        if self.args.issue_type and not self.args.issue_type.lower() in list(self.jira.get_issue_types().keys()) + list(self.jira.get_subtask_issue_types().keys()):
+        issue_types = []
+        if sys.version_info >= (3,0):
+            issue_types = list(self.jira.get_issue_types().keys()) + list(self.jira.get_subtask_issue_types().keys())
+        else:
+            issue_types = self.jira.get_issue_types().keys() + self.jira.get_subtask_issue_types().keys()
+        if self.args.issue_type and not self.args.issue_type.lower() in issue_types):
             raise UsageError(
                 "invalid issue type: %s (try using jira-cli "
                 "list issue_types or jira-cli list subtask_types)" % self.args.issue_type

--- a/jiracli/processor.py
+++ b/jiracli/processor.py
@@ -3,8 +3,6 @@
 """
 from abc import ABCMeta, abstractmethod
 
-import sys
-
 import json
 import six
 
@@ -214,12 +212,7 @@ class AddCommand(Command):
             raise UsageError('project must be specified when creating an issue')
         if not (self.args.issue_parent or self.args.issue_type):
             self.args.issue_type = 'bug'
-        issue_types = []
-        if sys.version_info >= (3,0):
-            issue_types = list(self.jira.get_issue_types().keys()) + list(self.jira.get_subtask_issue_types().keys())
-        else:
-            issue_types = self.jira.get_issue_types().keys() + self.jira.get_subtask_issue_types().keys()
-        if self.args.issue_type and not self.args.issue_type.lower() in issue_types:
+        if self.args.issue_type and not self.args.issue_type.lower() in list(self.jira.get_issue_types().keys()) + list(self.jira.get_subtask_issue_types().keys()):
             raise UsageError(
                 "invalid issue type: %s (try using jira-cli "
                 "list issue_types or jira-cli list subtask_types)" % self.args.issue_type


### PR DESCRIPTION
The following happens when trying to create a new issue in Python3:
TypeError: unsupported operand type(s) for +: 'dict_keys' and 'dict_keys'

This is fixed by putting the keys into lists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alisaifee/jira-cli/65)
<!-- Reviewable:end -->
