### PR TITLE
encode message as utf-8 before printing

### DIFF
--- a/jiracli/utils.py
+++ b/jiracli/utils.py
@@ -162,7 +162,7 @@ def print_error(msg, severity=CRITICAL):
     sys.stderr.write(colorfunc(msg, color) + "\n")
 
 def print_output(msg):
-    print(msg)
+    print(msg.encode('utf-8'))
 
 def prompt(msg, masked=False):
     if not masked:


### PR DESCRIPTION
Encodes message before printing. This fixes a bug I encountered when the description of a ticket contains a non ascii character:

```
$ jira-cli view ABC-123 -vvv  | cat
Traceback (most recent call last):
  File "/usr/local/bin/jira-cli", line 11, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python2.7/site-packages/jiracli/interface.py", line 272, in cli
    return post_args.cmd(jira, post_args).execute()
  File "/usr/local/lib/python2.7/site-packages/jiracli/processor.py", line 30, in execute
    return self.eval()
  File "/usr/local/lib/python2.7/site-packages/jiracli/processor.py", line 75, in eval
    comments_only=self.args.comments_only
  File "/usr/local/lib/python2.7/site-packages/jiracli/utils.py", line 165, in print_output
    print(msg)
UnicodeEncodeError: 'ascii' codec can't encode character u'\xa0' in position 166: ordinal not in range(128)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alisaifee/jira-cli/76)
<!-- Reviewable:end -->
