### PR TITLE
Fix issue with python3 non-addable dict_keys type

### DIFF
--- a/jiracli/processor.py
+++ b/jiracli/processor.py
@@ -210,9 +210,10 @@ class AddCommand(Command):
             extras = self.extract_extras()
         if not self.args.issue_project:
             raise UsageError('project must be specified when creating an issue')
+
         if not (self.args.issue_parent or self.args.issue_type):
             self.args.issue_type = 'bug'
-        if self.args.issue_type and not self.args.issue_type.lower() in self.jira.get_issue_types().keys() + self.jira.get_subtask_issue_types().keys():
+        if self.args.issue_type and not self.args.issue_type.lower() in set(self.jira.get_issue_types().keys()).union(set(self.jira.get_subtask_issue_types().keys())):
             raise UsageError(
                 "invalid issue type: %s (try using jira-cli "
                 "list issue_types or jira-cli list subtask_types)" % self.args.issue_type

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,0 +1,15 @@
+import unittest
+
+import mock
+
+from jiracli.interface import build_parser, cli
+
+class AddCommandTests(unittest.TestCase):
+    def test_issue_type_parsing(self):
+        "Previously, calling this would raise an exception on python3"
+        with mock.patch("jiracli.interface.print_output"):
+            with mock.patch("jiracli.interface.prompt") as prompt:
+                with mock.patch("jiracli.interface.initialize") as init:
+                    init().get_issue_types.return_value = {'story': 1}
+                    cli("new title --type story --project FOO --description bar".split(" "))
+


### PR DESCRIPTION
In my version of python3 (3.8.2) you can't add the keys of a dict together. This fixes that isssue and has a test which validates it.

```
$ python3
Python 3.8.2 (default, Jul 16 2020, 14:00:26) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> z = {'a': 2}
>>> z.keys() + z.keys()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: unsupported operand type(s) for +: 'dict_keys' and 'dict_keys'


$ python2
Python 2.7.18rc1 (default, Apr  7 2020, 12:05:55) 
[GCC 9.3.0] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> z = {'a': 2}
>>> z.keys() + z.keys()
['a', 'a']
>>> 
```